### PR TITLE
FOGL-7807: Macro substitution added to OMFHint Filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Fledge "omfhint" Filter plugin
 ==============================
 
 A filter plugin that allows OMFHint's to be added to the readings that
-will be passed to the OMF plugin to inflience how the data is stored
-within The OSIsoft PI Server.
+will be passed to the OMF plugin to influence how the data is stored
+within the OSIsoft PI Server.
 
 `See documentation <docs/index.rst>`_

--- a/README.rst
+++ b/README.rst
@@ -5,3 +5,5 @@ Fledge "omfhint" Filter plugin
 A filter plugin that allows OMFHint's to be added to the readings that
 will be passed to the OMF plugin to inflience how the data is stored
 within The OSIsoft PI Server.
+
+`See documentation <docs/index.rst>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,7 +164,7 @@ Macro substitution
 
 Simple macro substitution within the values of the hints based on the content of the reading can be done.
 
-Macro **$voltage_uom$** and **$current_uom$** will be replaced by the value of datapoint **voltage_uom** and **current_uom** respectively.
+Macro ```$voltage_uom$``` and ```$current_uom$``` will be replaced by the value of datapoint **voltage_uom** and **current_uom** respectively.
 
 .. code-block:: JSON
 
@@ -186,7 +186,7 @@ Macro **$voltage_uom$** and **$current_uom$** will be replaced by the value of d
    	}
    }
 
-Macro **$ASSET$** will be replaced by asset name. Other macros **$city$**, **$factory$** and **$floor$** will be replaced by the value of datapoint **city**, **factory** and **floor** respectively.
+Macro ```$ASSET$``` will be replaced by asset name. Other macros ```$city$```, ```$factory$``` and ```$floor$``` will be replaced by the value of datapoint **city**, **factory** and **floor** respectively.
 
 .. code-block:: JSON
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,7 +138,6 @@ datapoint item.
 
    {
    	"motor4": {
-   		"OMFHint": {
    			"datapoint": [{
    					"name": "voltage",
    					"number": "float32",
@@ -150,7 +149,6 @@ datapoint item.
    					"uom": "milliampere"
    				}
    			]
-   		}
    	}
    }
 
@@ -170,7 +168,6 @@ Macro ``$voltage_uom$`` and ``$current_uom$`` will be replaced by the value of d
 
    {
    	"motor4": {
-   		"OMFHint": {
    			"datapoint": [{
    					"name": "voltage",
    					"number": "float32",
@@ -182,7 +179,6 @@ Macro ``$voltage_uom$`` and ``$current_uom$`` will be replaced by the value of d
    					"uom": "$current_uom$"
    				}
    			]
-   		}
    	}
    }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,3 +158,43 @@ The example above attaches a number hint to both the voltage and current
 datapoints and to the current datapoint. It assigns a unit of measure
 of milliampere. The unit of measure for the voltage is set to be volts.
 
+
+Macro substitution
+------------------
+
+Simple macro substitution within the values of the hints based on the content of the reading can be done.
+
+Macro **$voltage_uom$** and **$current_uom$** will be replaced by the value of datapoint **voltage_uom** and **current_uom** respectively.
+
+.. code-block:: JSON
+
+   {
+   	"motor4": {
+   		"OMFHint": {
+   			"datapoint": [{
+   					"name": "voltage",
+   					"number": "float32",
+   					"uom": "$voltage_uom$"
+   				},
+   				{
+   					"name": "current",
+   					"number": "uint32",
+   					"uom": "$current_uom$"
+   				}
+   			]
+   		}
+   	}
+   }
+
+Macro **$ASSET$** will be replaced by asset name. Other macros **$city$**, **$factory$** and **$floor$** will be replaced by the value of datapoint **city**, **factory** and **floor** respectively.
+
+.. code-block:: JSON
+
+   {
+   	"motor4": {
+   		"OMFHint": {
+   			"AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$"
+   		}
+   	}
+   }
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,7 +164,7 @@ Macro substitution
 
 Simple macro substitution within the values of the hints based on the content of the reading can be done.
 
-Macro ```$voltage_uom$``` and ```$current_uom$``` will be replaced by the value of datapoint **voltage_uom** and **current_uom** respectively.
+Macro ``$voltage_uom$`` and ``$current_uom$`` will be replaced by the value of datapoint **voltage_uom** and **current_uom** respectively.
 
 .. code-block:: JSON
 
@@ -186,7 +186,7 @@ Macro ```$voltage_uom$``` and ```$current_uom$``` will be replaced by the value 
    	}
    }
 
-Macro ```$ASSET$``` will be replaced by asset name. Other macros ```$city$```, ```$factory$``` and ```$floor$``` will be replaced by the value of datapoint **city**, **factory** and **floor** respectively.
+Macro ``$ASSET$`` will be replaced by asset name. Other macros ``$city$``, ``$factory$`` and ``$floor$`` will be replaced by the value of datapoint **city**, **factory** and **floor** respectively.
 
 .. code-block:: JSON
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,9 +192,7 @@ Macro ``$ASSET$`` will be replaced by asset name. Other macros ``$city$``, ``$fa
 
    {
    	"motor4": {
-   		"OMFHint": {
    			"AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$"
-   		}
    	}
    }
 

--- a/include/omfhint.h
+++ b/include/omfhint.h
@@ -28,6 +28,6 @@ class OMFHintFilter : public FledgeFilter {
 		void	ReplaceMacros(Reading * reading, std::string& hintsJSON);
 
 		std::map<std::string, std::string>               m_hints;
+		std::vector<std::pair<std::string, int>>         m_macro_dp;
 		std::vector<std::pair<std::regex, std::string>> m_wildcards;
-		std::vector<std::string> m_macro_dpName;
 };

--- a/include/omfhint.h
+++ b/include/omfhint.h
@@ -24,7 +24,10 @@ class OMFHintFilter : public FledgeFilter {
 		void	reconfigure(const std::string& newConfig);
 	private:
 		void	configure(const ConfigCategory& config);
+		void	collectMacrosInfo(std::string hintsJSON);
+		void	ReplaceMacros(Reading * reading, std::string& hintsJSON);
 
 		std::map<std::string, std::string>               m_hints;
 		std::vector<std::pair<std::regex, std::string>> m_wildcards;
+		std::vector<std::string> m_macro_dpName;
 };

--- a/omfhint.cpp
+++ b/omfhint.cpp
@@ -59,7 +59,7 @@ OMFHintFilter::ingest(vector<Reading *> *readings, vector<Reading *>& out)
 		if (it != m_hints.end())
 		{
 			std::string hintsJSON = it->second;
-			if (m_macro_dpName.size())
+			if (!m_macro_dpName.empty())
 				ReplaceMacros(*elem, hintsJSON);
 			DatapointValue value(hintsJSON);
 			(*elem)->addDatapoint(new Datapoint("OMFHint", value));
@@ -76,7 +76,7 @@ OMFHintFilter::ingest(vector<Reading *> *readings, vector<Reading *>& out)
 					if (std::regex_match (name, item.first))
 					{
 						std::string hintsJSON = item.second;
-						if (m_macro_dpName.size())
+						if (!m_macro_dpName.empty())
 							ReplaceMacros(*elem, hintsJSON);
 						DatapointValue value(hintsJSON);
 						(*elem)->addDatapoint(new Datapoint("OMFHint", value));
@@ -161,7 +161,7 @@ OMFHintFilter::configure(const ConfigCategory& config)
 }
 
 /**
- * Extract datapoint name for marco replacement
+ * Extract datapoint name for macro replacement
  *
  * @param hintsJson	OMFHints JSON
  */

--- a/omfhint.cpp
+++ b/omfhint.cpp
@@ -149,7 +149,7 @@ OMFHintFilter::configure(const ConfigCategory& config)
 				} else {
 					m_hints.insert(pair<string, string>(asset, escaped));
 				}
-				// Check if macro substituion is requried
+				// Check if macro substituion is required
 				// At least one pair of '$' sign must be there to apply macro
 				if (std::count(escaped.begin(), escaped.end(), '$') > 1)
 					isMacro = true;

--- a/omfhint.cpp
+++ b/omfhint.cpp
@@ -148,7 +148,7 @@ OMFHintFilter::configure(const ConfigCategory& config)
 				} else {
 					m_hints.insert(pair<string, string>(asset, escaped));
 				}
-				// Check if macro substituion is required
+				// Check if macro substitution is required
 				// At least one pair of '$' sign must be there to apply macro
 				if (std::count(escaped.begin(), escaped.end(), '$') > 1)
 					collectMacrosInfo(escaped.c_str());
@@ -208,7 +208,7 @@ void OMFHintFilter::ReplaceMacros(Reading *reading, std::string &hintsJSON)
 				dataType != DatapointValue::dataTagType::T_FLOAT
 			)
 			{
-				Logger::getLogger()->warn("The datapoint %s can not be used as a macro substitution in the OMF Hint as it is not a string or numeric value",(*it).first.c_str());
+				Logger::getLogger()->warn("The datapoint %s cannot be used as a macro substitution in the OMF Hint as it is not a string or numeric value",(*it).first.c_str());
 				continue;
 			}
 			string datapointValue = "";

--- a/omfhint.cpp
+++ b/omfhint.cpp
@@ -189,6 +189,7 @@ void OMFHintFilter::ReplaceMacros(Reading *reading, std::string &hintsJSON)
 	// Replace Macros by datapoint value
 	for ( auto dpName : m_macro_dpName)
 	{
+		// In case of ASSET Macro, replace it by asset name instead of datapoint value
 		if (dpName == "ASSET")
 		{
 			StringReplaceAll(hintsJSON, "$ASSET$", reading->getAssetName());
@@ -198,6 +199,18 @@ void OMFHintFilter::ReplaceMacros(Reading *reading, std::string &hintsJSON)
 
 		if (datapoint)
 		{
+			// Check for datapoint type for string and numbers
+			DatapointValue::dataTagType dataType = datapoint->getData().getType();
+			if (
+				dataType != DatapointValue::dataTagType::T_STRING &&
+				dataType != DatapointValue::dataTagType::T_INTEGER &&
+				dataType != DatapointValue::dataTagType::T_FLOAT
+			)
+			{
+				Logger::getLogger()->warn("Only string and number are supported for macro");
+				continue;
+			}
+
 			string datapointValue = datapoint->getData().toString();
 
 			// Strip quotes from begining and end
@@ -209,6 +222,5 @@ void OMFHintFilter::ReplaceMacros(Reading *reading, std::string &hintsJSON)
 			}
 			StringReplaceAll(hintsJSON, "$" + dpName + "$", datapointValue);
 		}
-
 	}
 }

--- a/tests/test_omfhint.cpp
+++ b/tests/test_omfhint.cpp
@@ -289,12 +289,12 @@ TEST(OMFHINT, OmfHintASSETMacroMissingDataPoints)
 
     outdp = points[2];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    // Except missing datapoint city other macros have repalced.
+    // Except missing datapoint city other macros have been replaced.
     ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}\"");
 }
 
 
-// Testing for differnet permutations for macro
+// Testing for different permutations for macro
 TEST(OMFHINT, OmfHintPermutationMacro)
 {
     const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/North$city$$factory$South/A$floor$B/$ASSET$" }})";
@@ -493,7 +493,7 @@ TEST(OMFHINT, OmfHintUnspportedMacro)
     vector<Reading *> *readings = new vector<Reading *>;
     vector<Datapoint *> dpValue;
 
-    //unspported DatapointValue::dataTagType::T_IMAGE datatype
+    //unsupported DatapointValue::dataTagType::T_IMAGE datatype
     void *data = malloc(100 * 100);
     DPImage *cityImage = new DPImage(100, 100, 8, data);
     
@@ -534,6 +534,6 @@ TEST(OMFHINT, OmfHintUnspportedMacro)
 
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    // Except unsupported datapoint city of image type other macros have been repalced.
+    // Except unsupported datapoint city of image type other macros have been replaced.
     ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}\"");
 }

--- a/tests/test_omfhint.cpp
+++ b/tests/test_omfhint.cpp
@@ -103,19 +103,17 @@ TEST(OMFHINT, OmfHintDatapointMacro)
 {
     const char *hintsJSON = R"({
      "motor4": {
-             "OMFHint": {
-                     "datapoint": [{
-                                     "name": "voltage",
-                                     "number": "float32",
-                                     "uom": "$voltage_uom$"
-                             },
-                             {
-                                     "name": "current",
-                                     "number": "uint32",
-                                     "uom": "$current_uom$"
-                             }
-                     ]
-             }
+                "datapoint": [{
+                                "name": "voltage",
+                                "number": "float32",
+                                "uom": "$voltage_uom$"
+                        },
+                        {
+                                "name": "current",
+                                "number": "uint32",
+                                "uom": "$current_uom$"
+                        }
+                ]
      }
     })";
 
@@ -177,7 +175,7 @@ TEST(OMFHINT, OmfHintDatapointMacro)
 
     outdp = points[4];
     ASSERT_STREQ(outdp->getName().c_str(),"OMFHint");
-    ASSERT_STREQ(outdp->getData().toString().c_str(), "\"{\\\"OMFHint\\\":{\\\"datapoint\\\":[{\\\"name\\\":\\\"voltage\\\",\\\"number\\\":\\\"float32\\\",\\\"uom\\\":\\\"Volt\\\"},{\\\"name\\\":\\\"current\\\",\\\"number\\\":\\\"uint32\\\",\\\"uom\\\":\\\"Ampere\\\"}]}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(), "\"{\\\"datapoint\\\":[{\\\"name\\\":\\\"voltage\\\",\\\"number\\\":\\\"float32\\\",\\\"uom\\\":\\\"Volt\\\"},{\\\"name\\\":\\\"current\\\",\\\"number\\\":\\\"uint32\\\",\\\"uom\\\":\\\"Ampere\\\"}]}\"");
 }
 
 // Testing for ASSET macro

--- a/tests/test_omfhint.cpp
+++ b/tests/test_omfhint.cpp
@@ -94,7 +94,7 @@ TEST(OMFHINT, OmfHintAddAssetDataPointHint)
 
     Datapoint *outdp = points[0];
     ASSERT_STREQ(outdp->getName().c_str(), "test");
-
+    
     outdp = points[1];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
 }
@@ -183,7 +183,7 @@ TEST(OMFHINT, OmfHintDatapointMacro)
 // Testing for ASSET macro
 TEST(OMFHINT, OmfHintASSETMacro)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -237,13 +237,13 @@ TEST(OMFHINT, OmfHintASSETMacro)
 
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/London/Plant1/12/Camera\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),   "\"{\\\"AFLocation\\\":\\\"/UK/London/Plant1/12/Camera\\\"}\"");
 }
 
 // Testing for missing datapoint city
 TEST(OMFHINT, OmfHintASSETMacroMissingDataPoints)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -290,14 +290,14 @@ TEST(OMFHINT, OmfHintASSETMacroMissingDataPoints)
     outdp = points[2];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
     // Except missing datapoint city other macros have repalced.
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}\"");
 }
 
 
 // Testing for differnet permutations for macro
 TEST(OMFHINT, OmfHintPermutationMacro)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/North$city$$factory$South/A$floor$B/$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/North$city$$factory$South/A$floor$B/$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -351,13 +351,13 @@ TEST(OMFHINT, OmfHintPermutationMacro)
 
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/NorthLondonPlant1South/A12B/Camera\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/NorthLondonPlant1South/A12B/Camera\\\"}\"");
 }
 
 // Testing for unpaired $ sign
 TEST(OMFHINT, OmfHintPermutationMacro2)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/$city$$factory$/$floor$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/$city$$factory$/$floor$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -411,13 +411,13 @@ TEST(OMFHINT, OmfHintPermutationMacro2)
 
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/LondonPlant1/12ASSET$\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/LondonPlant1/12ASSET$\\\"}\"");
 }
 
 // Testing for ASSET macro
 TEST(OMFHINT, OmfHintCaseSensitivityMacro)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/$city$/$Factory$/$Floor$/$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/$city$/$Factory$/$Floor$/$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -471,13 +471,13 @@ TEST(OMFHINT, OmfHintCaseSensitivityMacro)
 
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/London/$Factory$/$Floor$/Camera\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/London/$Factory$/$Floor$/Camera\\\"}\"");
 }
 
 // Testing macro for unsupported datatype for city datapoint
 TEST(OMFHINT, OmfHintUnspportedMacro)
 {
-    const char *hintsJSON = R"({"Camera": {"OMFHint"  : { "AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }}})";
+    const char *hintsJSON = R"({"Camera": {"AFLocation" : "/UK/$city$/$factory$/$floor$/$ASSET$" }})";
 
     PLUGIN_INFORMATION *info = plugin_info();
     ConfigCategory *config = new ConfigCategory("omfhint", info->config);
@@ -535,5 +535,5 @@ TEST(OMFHINT, OmfHintUnspportedMacro)
     outdp = points[3];
     ASSERT_STREQ(outdp->getName().c_str(), "OMFHint");
     // Except unsupported datapoint city of image type other macros have been repalced.
-    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"OMFHint\\\":{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}}\"");
+    ASSERT_STREQ(outdp->getData().toString().c_str(),  "\"{\\\"AFLocation\\\":\\\"/UK/$city$/Plant1/12/Camera\\\"}\"");
 }


### PR DESCRIPTION
Unit Test result
```
./RunTests

Repeating all tests (iteration 1) . . .

Note: Randomizing tests' orders with a seed of 87136 .
[==========] Running 11 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 2 tests from OMFHINT_INFO
[ RUN      ] OMFHINT_INFO.PluginInfoConfigParse
[       OK ] OMFHINT_INFO.PluginInfoConfigParse (0 ms)
[ RUN      ] OMFHINT_INFO.PluginInfo
[       OK ] OMFHINT_INFO.PluginInfo (0 ms)
[----------] 2 tests from OMFHINT_INFO (0 ms total)

[----------] 9 tests from OMFHINT
[ RUN      ] OMFHINT.OmfHintCaseSensitivityMacro
[       OK ] OMFHINT.OmfHintCaseSensitivityMacro (1 ms)
[ RUN      ] OMFHINT.OmfHintDatapointMacro
[       OK ] OMFHINT.OmfHintDatapointMacro (1 ms)
[ RUN      ] OMFHINT.OmfHintASSETMacro
[       OK ] OMFHINT.OmfHintASSETMacro (1 ms)
[ RUN      ] OMFHINT.OmfHintUnspportedMacro
[       OK ] OMFHINT.OmfHintUnspportedMacro (2 ms)
[ RUN      ] OMFHINT.OmfHintPermutationMacro2
[       OK ] OMFHINT.OmfHintPermutationMacro2 (1 ms)
[ RUN      ] OMFHINT.OmfHintDisabled
[       OK ] OMFHINT.OmfHintDisabled (1 ms)
[ RUN      ] OMFHINT.OmfHintAddAssetDataPointHint
[       OK ] OMFHINT.OmfHintAddAssetDataPointHint (1 ms)
[ RUN      ] OMFHINT.OmfHintASSETMacroMissingDataPoints
[       OK ] OMFHINT.OmfHintASSETMacroMissingDataPoints (1 ms)
[ RUN      ] OMFHINT.OmfHintPermutationMacro
[       OK ] OMFHINT.OmfHintPermutationMacro (2 ms)
[----------] 9 tests from OMFHINT (33 ms total)

[----------] Global test environment tear-down
[==========] 11 tests from 2 test cases ran. (39 ms total)
[  PASSED  ] 11 tests.

```